### PR TITLE
change minimum php version to 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.1
   - 7.2
   - 7.3
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "source": "https://github.com/yiisoft/event-dispatcher"
     },
     "require": {
-        "php": "^7.1.0",
+        "php": "^7.2",
         "psr/event-dispatcher": "1.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
`psr/event-dispatcher` uses `object` as a type for events, `object` type was introduced in PHP 7.2, therefore any implementation of PSR-14 MUST require 7.2 as minimum.


| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

