### PR TITLE
Add missing PHP types to properties/methods/parameters

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -12,23 +12,13 @@ use Psr\EventDispatcher\StoppableEventInterface;
  */
 final class Dispatcher implements EventDispatcherInterface
 {
-    /**
-     * @var ListenerProviderInterface
-     */
     private ListenerProviderInterface $listenerProvider;
 
-    /**
-     * @param ListenerProviderInterface $listenerProvider
-     */
     public function __construct(ListenerProviderInterface $listenerProvider)
     {
         $this->listenerProvider = $listenerProvider;
     }
 
-    /**
-     * @param object $event
-     * @return object
-     */
     public function dispatch(object $event): object
     {
         foreach ($this->listenerProvider->getListenersForEvent($event) as $listener) {

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -12,14 +12,24 @@ use Psr\EventDispatcher\StoppableEventInterface;
  */
 final class Dispatcher implements EventDispatcherInterface
 {
-    private $listenerProvider;
+    /**
+     * @var ListenerProviderInterface
+     */
+    private ListenerProviderInterface $listenerProvider;
 
+    /**
+     * @param ListenerProviderInterface $listenerProvider
+     */
     public function __construct(ListenerProviderInterface $listenerProvider)
     {
         $this->listenerProvider = $listenerProvider;
     }
 
-    public function dispatch(object $event)
+    /**
+     * @param object $event
+     * @return object
+     */
+    public function dispatch(object $event): object
     {
         foreach ($this->listenerProvider->getListenersForEvent($event) as $listener) {
             if ($event instanceof StoppableEventInterface && $event->isPropagationStopped()) {

--- a/src/Provider/Aggregate.php
+++ b/src/Provider/Aggregate.php
@@ -13,8 +13,12 @@ final class Aggregate implements ListenerProviderInterface
     /**
      * @var ListenerProviderInterface[]
      */
-    private $providers;
+    private array $providers = [];
 
+    /**
+     * @param object $event
+     * @return iterable<callable>
+     */
     public function getListenersForEvent(object $event): iterable
     {
         foreach ($this->providers as $provider) {

--- a/src/Provider/Aggregate.php
+++ b/src/Provider/Aggregate.php
@@ -15,10 +15,6 @@ final class Aggregate implements ListenerProviderInterface
      */
     private array $providers = [];
 
-    /**
-     * @param object $event
-     * @return iterable<callable>
-     */
     public function getListenersForEvent(object $event): iterable
     {
         foreach ($this->providers as $provider) {

--- a/src/Provider/Provider.php
+++ b/src/Provider/Provider.php
@@ -15,10 +15,6 @@ final class Provider implements ListenerProviderInterface
      */
     private array $listeners = [];
 
-    /**
-     * @param object $event
-     * @return iterable<callable>
-     */
     public function getListenersForEvent(object $event): iterable
     {
         $className = get_class($event);

--- a/src/Provider/Provider.php
+++ b/src/Provider/Provider.php
@@ -10,8 +10,15 @@ use Psr\EventDispatcher\ListenerProviderInterface;
  */
 final class Provider implements ListenerProviderInterface
 {
-    private $listeners = [];
+    /**
+     * @var callable[]
+     */
+    private array $listeners = [];
 
+    /**
+     * @param object $event
+     * @return iterable<callable>
+     */
     public function getListenersForEvent(object $event): iterable
     {
         $className = get_class($event);

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -10,7 +10,7 @@ use Yiisoft\EventDispatcher\Tests\Event\StoppableEvent;
 
 class DispatcherTest extends TestCase
 {
-    public function testCallsAllListeners()
+    public function testCallsAllListeners(): void
     {
         $event = new Event();
 
@@ -35,7 +35,7 @@ class DispatcherTest extends TestCase
         $this->assertEquals([1, 2, 3], $event->registered());
     }
 
-    public function testPropagationStops()
+    public function testPropagationStops(): void
     {
         $event = new StoppableEvent();
 

--- a/tests/Event/Event.php
+++ b/tests/Event/Event.php
@@ -4,13 +4,19 @@ namespace Yiisoft\EventDispatcher\Tests\Event;
 
 class Event
 {
-    private $registered = [];
+    /**
+     * @var string[]
+     */
+    private array $registered = [];
 
     public function register(string $name): void
     {
         $this->registered[] = $name;
     }
 
+    /**
+     * @return string[]
+     */
     public function registered(): array
     {
         return $this->registered;

--- a/tests/Event/StoppableEvent.php
+++ b/tests/Event/StoppableEvent.php
@@ -6,9 +6,6 @@ use Psr\EventDispatcher\StoppableEventInterface;
 
 class StoppableEvent extends Event implements StoppableEventInterface
 {
-    /**
-     * @var bool
-     */
     private bool $isPropagationStopped = false;
 
     public function isPropagationStopped(): bool

--- a/tests/Event/StoppableEvent.php
+++ b/tests/Event/StoppableEvent.php
@@ -6,14 +6,17 @@ use Psr\EventDispatcher\StoppableEventInterface;
 
 class StoppableEvent extends Event implements StoppableEventInterface
 {
-    private $isPropagationStopped = false;
+    /**
+     * @var bool
+     */
+    private bool $isPropagationStopped = false;
 
     public function isPropagationStopped(): bool
     {
         return $this->isPropagationStopped;
     }
 
-    public function stopPropagation()
+    public function stopPropagation(): void
     {
         $this->isPropagationStopped = true;
     }

--- a/tests/Listener/Invokable.php
+++ b/tests/Listener/Invokable.php
@@ -6,7 +6,7 @@ use Yiisoft\EventDispatcher\Tests\Event\Event;
 
 class Invokable
 {
-    public function __invoke(Event $event)
+    public function __invoke(Event $event): void
     {
         // do nothing
     }

--- a/tests/Listener/NonStatic.php
+++ b/tests/Listener/NonStatic.php
@@ -6,7 +6,7 @@ use Yiisoft\EventDispatcher\Tests\Event\Event;
 
 class NonStatic
 {
-    public function handle(Event $event)
+    public function handle(Event $event): void
     {
         // do nothing
     }

--- a/tests/Listener/WithStaticMethod.php
+++ b/tests/Listener/WithStaticMethod.php
@@ -6,7 +6,7 @@ use Yiisoft\EventDispatcher\Tests\Event\Event;
 
 class WithStaticMethod
 {
-    public static function handle(Event $event)
+    public static function handle(Event $event): void
     {
         // do nothing
     }

--- a/tests/Provider/ProviderTest.php
+++ b/tests/Provider/ProviderTest.php
@@ -15,7 +15,7 @@ use Yiisoft\EventDispatcher\Tests\Listener\WithStaticMethod;
 
 class ProviderTest extends TestCase
 {
-    public function testAttachCallableArray()
+    public function testAttachCallableArray(): void
     {
         $provider = new Provider();
         $provider->attach([WithStaticMethod::class, 'handle']);
@@ -24,7 +24,7 @@ class ProviderTest extends TestCase
         $this->assertCount(1, $listeners);
     }
 
-    public function testAttachCallableFunction()
+    public function testAttachCallableFunction(): void
     {
         $provider = new Provider();
         $provider->attach('Yiisoft\EventDispatcher\Tests\Provider\handle');
@@ -33,7 +33,7 @@ class ProviderTest extends TestCase
         $this->assertCount(1, $listeners);
     }
 
-    public function testAttachClosure()
+    public function testAttachClosure(): void
     {
         $provider = new Provider();
         $provider->attach(function (Event $event) {
@@ -44,7 +44,7 @@ class ProviderTest extends TestCase
         $this->assertCount(1, $listeners);
     }
 
-    public function testAttachCallableObject()
+    public function testAttachCallableObject(): void
     {
         $provider = new Provider();
         $provider->attach([new NonStatic(), 'handle']);
@@ -53,7 +53,7 @@ class ProviderTest extends TestCase
         $this->assertCount(1, $listeners);
     }
 
-    public function testInvokable()
+    public function testInvokable(): void
     {
         $provider = new Provider();
         $provider->attach(new Invokable());
@@ -62,7 +62,7 @@ class ProviderTest extends TestCase
         $this->assertCount(1, $listeners);
     }
 
-    public function testListenersForClassHierarchyAreReturned()
+    public function testListenersForClassHierarchyAreReturned(): void
     {
         $provider = new Provider();
 
@@ -100,7 +100,7 @@ class ProviderTest extends TestCase
     }
 }
 
-function handle(Event $event)
+function handle(Event $event): void
 {
     // do nothing
 }


### PR DESCRIPTION
This library requires PHP 7.4 as a minimal dependency version.
Therefore, the property/method/parameter typing system should be fully
embraced.

This could also ease the use of a static-analysis tool in the future.

I'm not sure what is the policy for php-docs in this library, please tell me if redundant doc-blocks should be removed.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
