### PR TITLE
Introduce concrete provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,24 @@ $aggregate->attach(new class implements ListenerProviderInterface {
 $dispatcher = new Yiisoft\EventDispatcher\Dispatcher($aggregate);
 ```
 
+## Register listeners with concrete event names
+
+You may use a more simple listener provider, which allows you to specify which event they can provide.
+
+It can be useful in some specific cases, for instance if one of your listeners does not need the event 
+object passed as a parameter (can happen if the listener only needs to run at a specific stage during 
+runtime, but does not need event data).
+
+In that case, it is advised to use the aggregate (see above) if you need features from both providers included
+in this library.
+
+```php
+$provider = new Yiisoft\EventDispatcher\Provider\ConcreteProvider();
+$provider->attach(SomeEvent::class, function () {
+    // this function does not need an event object as argument
+});
+```
+
 ## Credits
 
 - Larry Garfield (@crell) for initial implementation of deriving callable parameter type.

--- a/src/Provider/ConcreteProvider.php
+++ b/src/Provider/ConcreteProvider.php
@@ -10,7 +10,7 @@ use function class_parents;
 use function get_class;
 
 /**
- * Provider is a listener provider that registers event listeners for interface names specified explicitly
+ * ConcreteProvider is a listener provider that registers event listeners for interface names specified explicitly
  * and gives out a list of handlers for further use with Dispatcher.
  *
  * ```php

--- a/src/Provider/ConcreteProvider.php
+++ b/src/Provider/ConcreteProvider.php
@@ -9,6 +9,17 @@ use function class_implements;
 use function class_parents;
 use function get_class;
 
+/**
+ * Provider is a listener provider that registers event listeners for interface names specified explicitly
+ * and gives out a list of handlers for further use with Dispatcher.
+ *
+ * ```php
+ * $provider = new Yiisoft\EventDispatcher\Provider\ConcreteProvider();
+ * $provider->attach(SomeEvent::class, function () {
+ *    // handle it
+ * });
+ * ```
+ */
 final class ConcreteProvider implements ListenerProviderInterface
 {
     /**

--- a/src/Provider/ConcreteProvider.php
+++ b/src/Provider/ConcreteProvider.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Yiisoft\EventDispatcher\Provider;
+
+use Psr\EventDispatcher\ListenerProviderInterface;
+
+use function array_values;
+use function class_implements;
+use function class_parents;
+use function get_class;
+
+final class ConcreteProvider implements ListenerProviderInterface
+{
+    /**
+     * @var callable[]
+     */
+    private array $listeners = [];
+
+    /**
+     * @param object $event
+     * @return iterable<callable>
+     */
+    public function getListenersForEvent(object $event): iterable
+    {
+        yield from $this->listenersFor(get_class($event));
+        yield from $this->listenersFor(...array_values(class_parents($event)));
+        yield from $this->listenersFor(...array_values(class_implements($event)));
+    }
+
+    /**
+     * Attach an event handler for the given event name
+     *
+     * @param string $eventName
+     * @param callable $listener
+     */
+    public function attach(string $eventName, callable $listener): void
+    {
+        $this->listeners[$eventName][] = $listener;
+    }
+
+    /**
+     * Detach all event handlers registered for an interface
+     *
+     * @param string $interface
+     */
+    public function detach(string $interface): void
+    {
+        unset($this->listeners[$interface]);
+    }
+
+    /**
+     * @param string ...$eventNames
+     * @return iterable<callable>
+     */
+    private function listenersFor(string ...$eventNames): iterable
+    {
+        foreach ($eventNames as $name) {
+            if (isset($this->listeners[$name])) {
+                yield from $this->listeners[$name];
+            }
+        }
+    }
+}

--- a/src/Provider/ConcreteProvider.php
+++ b/src/Provider/ConcreteProvider.php
@@ -41,11 +41,11 @@ final class ConcreteProvider implements ListenerProviderInterface
     /**
      * Detach all event handlers registered for an interface
      *
-     * @param string $interface
+     * @param string $eventName
      */
-    public function detach(string $interface): void
+    public function detach(string $eventName): void
     {
-        unset($this->listeners[$interface]);
+        unset($this->listeners[$eventName]);
     }
 
     /**

--- a/src/Provider/Provider.php
+++ b/src/Provider/Provider.php
@@ -15,6 +15,11 @@ final class Provider implements ListenerProviderInterface
      */
     private ConcreteProvider $concreteProvider;
 
+    public function __construct()
+    {
+        $this->concreteProvider = new ConcreteProvider();
+    }
+
     /**
      * @param object $event
      * @return iterable<callable>
@@ -41,7 +46,7 @@ final class Provider implements ListenerProviderInterface
     {
         $eventName = $this->getParameterType($listener);
 
-        $this->concreteProvider()->attach($eventName, $listener);
+        $this->concreteProvider->attach($eventName, $listener);
     }
 
     /**
@@ -51,7 +56,7 @@ final class Provider implements ListenerProviderInterface
      */
     public function detach(string $interface): void
     {
-        $this->concreteProvider()->detach($interface);
+        $this->concreteProvider->detach($interface);
     }
 
     /**
@@ -162,13 +167,5 @@ final class Provider implements ListenerProviderInterface
     private function isClassCallable($callable): bool
     {
         return is_array($callable) && is_string($callable[0]) && class_exists($callable[0]);
-    }
-
-    /**
-     * @return ConcreteProvider
-     */
-    private function concreteProvider(): ConcreteProvider
-    {
-        return $this->concreteProvider ??= new ConcreteProvider();
     }
 }

--- a/src/Provider/Provider.php
+++ b/src/Provider/Provider.php
@@ -20,9 +20,6 @@ use Psr\EventDispatcher\ListenerProviderInterface;
  */
 final class Provider implements ListenerProviderInterface
 {
-    /**
-     * @var ConcreteProvider
-     */
     private ConcreteProvider $concreteProvider;
 
     public function __construct()

--- a/src/Provider/Provider.php
+++ b/src/Provider/Provider.php
@@ -7,6 +7,16 @@ use Psr\EventDispatcher\ListenerProviderInterface;
 /**
  * Provider is a listener provider that registers event listeners for interfaces used in callable type-hints
  * and gives out a list of handlers by event interface provided for further use with Dispatcher.
+ *
+ * ```php
+ * $provider = new Yiisoft\EventDispatcher\Provider\Provider();
+ *
+ * // adding some listeners
+ * $provider->attach(function (AfterDocumentProcessed $event) {
+ *    $document = $event->getDocument();
+ *    // do something with document
+ * });
+ * ```
  */
 final class Provider implements ListenerProviderInterface
 {

--- a/tests/Provider/ConcreteProviderTest.php
+++ b/tests/Provider/ConcreteProviderTest.php
@@ -24,6 +24,7 @@ final class ConcreteProviderTest extends TestCase
 
         $listeners = $provider->getListenersForEvent(new Event());
 
+        $listeners = \iterator_to_array($listeners, false);
         $this->assertCount(1, $listeners);
         $this->assertContains($listener, $listeners);
     }

--- a/tests/Provider/ConcreteProviderTest.php
+++ b/tests/Provider/ConcreteProviderTest.php
@@ -24,7 +24,8 @@ final class ConcreteProviderTest extends TestCase
 
         $listeners = $provider->getListenersForEvent(new Event());
 
-        $this->assertEquals([$listener], $listeners);
+        $this->assertCount(1, $listeners);
+        $this->assertContains($listener, $listeners);
     }
 
     public function testDetachListenersForEventAreDetached(): void

--- a/tests/Provider/ConcreteProviderTest.php
+++ b/tests/Provider/ConcreteProviderTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Yiisoft\EventDispatcher\Tests\Provider;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\EventDispatcher\Provider\ConcreteProvider;
+use Yiisoft\EventDispatcher\Tests\Event\ClassInterface;
+use Yiisoft\EventDispatcher\Tests\Event\ClassItself;
+use Yiisoft\EventDispatcher\Tests\Event\Event;
+use Yiisoft\EventDispatcher\Tests\Event\ParentClass;
+use Yiisoft\EventDispatcher\Tests\Event\ParentInterface;
+
+use function array_slice;
+
+class ConcreteProviderTest extends TestCase
+{
+    /**
+     * @var ConcreteProvider
+     */
+    private ConcreteProvider $concreteProvider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->concreteProvider = new ConcreteProvider();
+    }
+
+    public function testListenerForEventIsReturned(): void
+    {
+        $listener = fn () => null;
+
+        $this->concreteProvider->attach(Event::class, $listener);
+
+        $listeners = $this->concreteProvider->getListenersForEvent(new Event());
+
+        $this->assertContains($listener, $listeners);
+    }
+
+    public function testDetachListenersForEventAreDetached(): void
+    {
+        $this->concreteProvider->attach(Event::class, fn () => null);
+        $this->concreteProvider->detach(Event::class);
+
+        $listeners = $this->concreteProvider->getListenersForEvent(new Event());
+
+        $this->assertCount(0, $listeners);
+    }
+
+    public function testListenersForClassHierarchyAreReturned(): void
+    {
+        $this->concreteProvider->attach(ParentInterface::class, function (ParentInterface $parentInterface) {
+            $parentInterface->register('parent interface');
+        });
+        $this->concreteProvider->attach(ParentClass::class, function (ParentClass $parentClass) {
+            $parentClass->register('parent class');
+        });
+        $this->concreteProvider->attach(ClassInterface::class, function (ClassInterface $classInterface) {
+            $classInterface->register('class interface');
+        });
+        $this->concreteProvider->attach(ClassItself::class, function (ClassItself $classItself) {
+            $classItself->register('class itself');
+        });
+
+        $event = new ClassItself();
+        foreach ($this->concreteProvider->getListenersForEvent($event) as $listener) {
+            $listener($event);
+        }
+
+        $classHierarchyHandlers = array_slice($event->registered(), 0, 2);
+        $interfaceHandlers = array_slice($event->registered(), 2);
+
+        $this->assertEquals(
+            [
+                'class itself',
+                'parent class',
+            ],
+            $classHierarchyHandlers
+        );
+
+        $this->assertContains('class interface', $interfaceHandlers);
+        $this->assertContains('parent interface', $interfaceHandlers);
+    }
+}

--- a/tests/Provider/ConcreteProviderTest.php
+++ b/tests/Provider/ConcreteProviderTest.php
@@ -12,58 +12,52 @@ use Yiisoft\EventDispatcher\Tests\Event\ParentInterface;
 
 use function array_slice;
 
-class ConcreteProviderTest extends TestCase
+final class ConcreteProviderTest extends TestCase
 {
-    /**
-     * @var ConcreteProvider
-     */
-    private ConcreteProvider $concreteProvider;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->concreteProvider = new ConcreteProvider();
-    }
-
     public function testListenerForEventIsReturned(): void
     {
+        $provider = $this->createConcreteProvider();
+
         $listener = fn () => null;
 
-        $this->concreteProvider->attach(Event::class, $listener);
+        $provider->attach(Event::class, $listener);
 
-        $listeners = $this->concreteProvider->getListenersForEvent(new Event());
+        $listeners = $provider->getListenersForEvent(new Event());
 
-        $this->assertContains($listener, $listeners);
+        $this->assertEquals([$listener], $listeners);
     }
 
     public function testDetachListenersForEventAreDetached(): void
     {
-        $this->concreteProvider->attach(Event::class, fn () => null);
-        $this->concreteProvider->detach(Event::class);
+        $provider = $this->createConcreteProvider();
 
-        $listeners = $this->concreteProvider->getListenersForEvent(new Event());
+        $provider->attach(Event::class, fn () => null);
+        $provider->detach(Event::class);
+
+        $listeners = $provider->getListenersForEvent(new Event());
 
         $this->assertCount(0, $listeners);
     }
 
     public function testListenersForClassHierarchyAreReturned(): void
     {
-        $this->concreteProvider->attach(ParentInterface::class, function (ParentInterface $parentInterface) {
+        $provider = $this->createConcreteProvider();
+
+        $provider->attach(ParentInterface::class, function (ParentInterface $parentInterface) {
             $parentInterface->register('parent interface');
         });
-        $this->concreteProvider->attach(ParentClass::class, function (ParentClass $parentClass) {
+        $provider->attach(ParentClass::class, function (ParentClass $parentClass) {
             $parentClass->register('parent class');
         });
-        $this->concreteProvider->attach(ClassInterface::class, function (ClassInterface $classInterface) {
+        $provider->attach(ClassInterface::class, function (ClassInterface $classInterface) {
             $classInterface->register('class interface');
         });
-        $this->concreteProvider->attach(ClassItself::class, function (ClassItself $classItself) {
+        $provider->attach(ClassItself::class, function (ClassItself $classItself) {
             $classItself->register('class itself');
         });
 
         $event = new ClassItself();
-        foreach ($this->concreteProvider->getListenersForEvent($event) as $listener) {
+        foreach ($provider->getListenersForEvent($event) as $listener) {
             $listener($event);
         }
 
@@ -80,5 +74,10 @@ class ConcreteProviderTest extends TestCase
 
         $this->assertContains('class interface', $interfaceHandlers);
         $this->assertContains('parent interface', $interfaceHandlers);
+    }
+
+    private function createConcreteProvider(): ConcreteProvider
+    {
+        return new ConcreteProvider();
     }
 }

--- a/tests/Provider/ProviderTest.php
+++ b/tests/Provider/ProviderTest.php
@@ -13,7 +13,7 @@ use Yiisoft\EventDispatcher\Tests\Listener\Invokable;
 use Yiisoft\EventDispatcher\Tests\Listener\NonStatic;
 use Yiisoft\EventDispatcher\Tests\Listener\WithStaticMethod;
 
-class ProviderTest extends TestCase
+final class ProviderTest extends TestCase
 {
     public function testAttachCallableArray(): void
     {


### PR DESCRIPTION
This listener provider is a more simple version which allows users to
specify which event types it can provide.

It can be useful in some specific cases, for instance if a listener does
not need the event object passed as a parameter (can happen if the
listener only needs to run at a specific stage during runtime, but does
not need event data).

Fixes #10

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #10
