### PR TITLE
Renamed Aggregate to CompositeProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,13 @@ $provider->attach(function (DocumentEvent $event) {
 
 ## Combining multiple listener providers
 
-In case you want to combine multiple listener providers, you can use `Aggregate`:
+In case you want to combine multiple listener providers, you can use `CompositeProvider`:
 
 ```php
-$aggregate = new Yiisoft\EventDispatcher\Provider\Aggregate();
-$provider1 = new Yiisoft\EventDispatcher\Provider\Provider();
-$aggregate->attach($provider1);
-$aggregate->attach(new class implements ListenerProviderInterface {
+$compositeProvider = new Yiisoft\EventDispatcher\Provider\CompositeProvider();
+$provider = new Yiisoft\EventDispatcher\Provider\Provider();
+$compositeProvider->attach($provider);
+$compositeProvider->attach(new class implements ListenerProviderInterface {
     public function getListenersForEvent(object $event): iterable
     {
         yield function ($event) {
@@ -114,7 +114,7 @@ $aggregate->attach(new class implements ListenerProviderInterface {
     }
 });
 
-$dispatcher = new Yiisoft\EventDispatcher\Dispatcher($aggregate);
+$dispatcher = new Yiisoft\EventDispatcher\Dispatcher($compositeProvider);
 ```
 
 ## Register listeners with concrete event names

--- a/src/Provider/CompositeProvider.php
+++ b/src/Provider/CompositeProvider.php
@@ -5,10 +5,9 @@ namespace Yiisoft\EventDispatcher\Provider;
 use Psr\EventDispatcher\ListenerProviderInterface;
 
 /**
- * Aggregate is a listener provider that allows combining
- * multiple listener providers.
+ * CompositeProvider is a listener provider that allows combining multiple listener providers.
  */
-final class Aggregate implements ListenerProviderInterface
+final class CompositeProvider implements ListenerProviderInterface
 {
     /**
      * @var ListenerProviderInterface[]

--- a/tests/Provider/CompositeTest.php
+++ b/tests/Provider/CompositeTest.php
@@ -4,10 +4,10 @@ namespace Yiisoft\EventDispatcher\Tests\Provider;
 
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\ListenerProviderInterface;
-use Yiisoft\EventDispatcher\Provider\Aggregate;
+use Yiisoft\EventDispatcher\Provider\CompositeProvider;
 use Yiisoft\EventDispatcher\Tests\Event\Event;
 
-class AggregateTest extends TestCase
+class CompositeTest extends TestCase
 {
     public function testProvidesAllListeners(): void
     {
@@ -31,7 +31,7 @@ class AggregateTest extends TestCase
             }
         };
 
-        $aggregate = new Aggregate();
+        $aggregate = new CompositeProvider();
 
         $aggregate->attach($provider1);
         $aggregate->attach($provider2);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Tests pass?   | ✔️

We have `CompositeContainer`, `CompositeDispatcher` (not ready yet) and `Aggregate` (nice name for provider :)).

I suggest to uniform name of "composite" classes to `Composite*` pattern. If anybody knows the same cases, let's fix it.